### PR TITLE
Friendships

### DIFF
--- a/app/controllers/friendships_controller.rb
+++ b/app/controllers/friendships_controller.rb
@@ -1,11 +1,11 @@
 class FriendshipsController < ApplicationController
   def create
-    @friend = User.find_by(handle: params[:follower])
+    @friend = User.find_by(handle: params[:future_friend])
     params[:friend_id] = @friend.id
     friendship = Friendship.create(friendship_params)
     if friendship.save
       redirect_to dashboard_path
-    end 
+    end
   end
 
   private

--- a/app/controllers/friendships_controller.rb
+++ b/app/controllers/friendships_controller.rb
@@ -1,0 +1,16 @@
+class FriendshipsController < ApplicationController
+  def create
+    @friend = User.find_by(handle: params[:follower])
+    params[:friend_id] = @friend.id
+    friendship = Friendship.create(friendship_params)
+    if friendship.save
+      redirect_to dashboard_path
+    end 
+  end
+
+  private
+
+  def friendship_params
+    params.permit(:user_id, :friend_id)
+  end
+end

--- a/app/models/follower.rb
+++ b/app/models/follower.rb
@@ -8,10 +8,13 @@ class Follower
   end
 
   def in_system?
-    binding.pry
+    @friend = User.find_by(handle: @handle)
+    @friend.present?
   end
 
-  def friend?
-    binding.pry
+  def already_friends?(user_id)
+    friendship = Friendship.find_by(friend_id: @friend.id, user_id: user_id)
+    friendship.present?
   end
+
 end

--- a/app/models/follower.rb
+++ b/app/models/follower.rb
@@ -6,4 +6,12 @@ class Follower
     @handle = follower_data[:login]
     @url = follower_data[:html_url]
   end
+
+  def in_system?
+    binding.pry
+  end
+
+  def friend?
+    binding.pry
+  end
 end

--- a/app/models/following.rb
+++ b/app/models/following.rb
@@ -7,9 +7,13 @@ class Following
     @url = following_data[:html_url]
   end
 
-  def in_system? 
+  def in_system?
+    @friend = User.find_by(handle: @handle)
+    @friend.present?
   end
 
-  def friend?
+  def already_friends?(user_id)
+    friendship = Friendship.find_by(friend_id: @friend.id, user_id: user_id)
+    friendship.present?
   end
 end

--- a/app/models/following.rb
+++ b/app/models/following.rb
@@ -6,4 +6,10 @@ class Following
     @handle = following_data[:login]
     @url = following_data[:html_url]
   end
+
+  def in_system? 
+  end
+
+  def friend?
+  end
 end

--- a/app/models/friendship.rb
+++ b/app/models/friendship.rb
@@ -1,0 +1,4 @@
+class Friendship < ApplicationRecord
+  belongs_to :user
+  belongs_to :friend, :class_name => 'User'
+end 

--- a/app/models/friendship.rb
+++ b/app/models/friendship.rb
@@ -1,4 +1,4 @@
 class Friendship < ApplicationRecord
   belongs_to :user
-  belongs_to :friend, :class_name => 'User'
-end 
+  belongs_to :friend, class_name: 'User'
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,7 +1,8 @@
 class User < ApplicationRecord
   has_many :user_videos, dependent: :destroy
   has_many :videos, through: :user_videos
-
+  has_many :friendships
+  has_many :friends, through: :friendships
   validates :email, uniqueness: true, presence: true
   validates :password, presence: true
   validates :first_name, presence: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,7 +2,8 @@ class User < ApplicationRecord
   has_many :user_videos, dependent: :destroy
   has_many :videos, through: :user_videos
   has_many :friendships
-  has_many :friends, through: :friendships
+  has_many :friends, through: :friendships 
+
   validates :email, uniqueness: true, presence: true
   validates :password, presence: true
   validates :first_name, presence: true

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -26,7 +26,7 @@
         <% @github_user.followers.each do |follower| %>
           <%= link_to follower.handle, follower.url %>
           <% if follower.in_system? && !follower.already_friends?(current_user.id) %>
-            <%= link_to "Add as Friend", "users/#{current_user.id}/friendships?follower=#{follower.handle}", method: :post, class: "btn btn-primary mb1 bg-teal" %><br>
+            <%= link_to "Add as Friend", "users/#{current_user.id}/friendships?future_friend=#{follower.handle}", method: :post, class: "btn btn-primary mb1 bg-teal" %><br>
           <% else %><br>
           <% end %>
         <% end %>
@@ -36,7 +36,7 @@
         <% @github_user.followings.each do |following| %>
           <%= link_to following.handle, following.url %><br>
           <% if following.in_system? && !following.already_friends?(current_user.id) %>
-            <%= link_to "Add as Friend", "users/#{current_user.id}/friendships?following=#{following.handle}", method: :post, class: "btn btn-primary mb1 bg-teal" %><br>
+            <%= link_to "Add as Friend", "users/#{current_user.id}/friendships?future_friend=#{following.handle}", method: :post, class: "btn btn-primary mb1 bg-teal" %><br>
           <% else %><br>
           <% end %>
         <% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -25,12 +25,20 @@
         <h2>Followers</h2>
         <% @github_user.followers.each do |follower| %>
           <%= link_to follower.handle, follower.url %><br>
+          <% if follower.in_system? && !follower.friend? %>
+            <%= link_to "Add as Friend", user_friendships_path %>
+          <% end %>
         <% end %>
       </section>
       <section class="following">
         <h2>Following</h2>
         <% @github_user.followings.each do |following| %>
           <%= link_to following.handle, following.url %><br>
+          <% if following.in_system? && !following.friend? %>
+            <%= link_to "Add as Friend", user_friendships_path %>
+          <% else %>
+            <%= "Already Friends" %>
+          <% end %>
         <% end %>
       </section>
     <%end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -24,9 +24,10 @@
       <section class="followers">
         <h2>Followers</h2>
         <% @github_user.followers.each do |follower| %>
-          <%= link_to follower.handle, follower.url %><br>
-          <% if follower.in_system? && !follower.friend? %>
-            <%= link_to "Add as Friend", user_friendships_path %>
+          <%= link_to follower.handle, follower.url %>
+          <% if follower.in_system? && !follower.already_friends?(current_user.id) %>
+            <%= link_to "Add as Friend", "users/#{current_user.id}/friendships?follower=#{follower.handle}", method: :post, class: "btn btn-primary mb1 bg-teal" %><br>
+          <% else %><br>
           <% end %>
         <% end %>
       </section>
@@ -34,13 +35,24 @@
         <h2>Following</h2>
         <% @github_user.followings.each do |following| %>
           <%= link_to following.handle, following.url %><br>
-          <% if following.in_system? && !following.friend? %>
-            <%= link_to "Add as Friend", user_friendships_path %>
-          <% else %>
-            <%= "Already Friends" %>
+          <% if following.in_system? && !following.already_friends?(current_user.id) %>
+            <%= link_to "Add as Friend", "users/#{current_user.id}/friendships?following=#{following.handle}", method: :post, class: "btn btn-primary mb1 bg-teal" %><br>
+          <% else %><br>
           <% end %>
         <% end %>
       </section>
-    <%end %>
+    <% end %>
+  </section>
+
+  <section class="friendships">
+    <h1>Friends</h1>
+    <% if current_user.friends.empty? %>
+      <%= "Bummer.You have no friends." %>
+    <% else %>
+      <% current_user.friends.each do |friend| %>
+        <%= friend.first_name %> <%= friend.last_name %> <br>
+        <%= friend.handle %>
+      <% end %>
+    <% end %>
   </section>
 </section>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -5,7 +5,7 @@
   <%= link_to 'Connect to Github', '/auth/github', class: "btn btn-primary mb1 bg-teal" %>
   <h3>Account Details</h3>
   <ul>
-    <li> <%= current_user.first_name  %> <%= current_user.last_name %> </li>
+    <li> <%= current_user.first_name %> <%= current_user.last_name %> </li>
     <li> <%= current_user.email%> </li>
   </ul>
   <section>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -37,7 +37,9 @@ Rails.application.routes.draw do
   # Is this being used?
   get '/video', to: 'video#show'
 
-  resources :users, only: [:new, :create, :update, :edit]
+  resources :users, only: [:new, :create, :update, :edit] do
+    resources :friendships, only: [:create]
+  end 
 
   resources :tutorials, only: [:show, :index] do
     resources :videos, only: [:show, :index]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -39,7 +39,7 @@ Rails.application.routes.draw do
 
   resources :users, only: [:new, :create, :update, :edit] do
     resources :friendships, only: [:create]
-  end 
+  end
 
   resources :tutorials, only: [:show, :index] do
     resources :videos, only: [:show, :index]

--- a/db/migrate/20200705210512_create_friendships.rb
+++ b/db/migrate/20200705210512_create_friendships.rb
@@ -1,0 +1,9 @@
+class CreateFriendships < ActiveRecord::Migration[5.2]
+  def change
+    create_table :friendships do |t|
+      t.belongs_to :user
+      t.belongs_to :friend, class: 'User'
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20200705210512_create_friendships.rb
+++ b/db/migrate/20200705210512_create_friendships.rb
@@ -2,7 +2,7 @@ class CreateFriendships < ActiveRecord::Migration[5.2]
   def change
     create_table :friendships do |t|
       t.belongs_to :user
-      t.belongs_to :friend, class: 'User'
+      t.belongs_to :friend
       t.timestamps
     end
   end

--- a/db/migrate/20200706013044_add_handle_to_users.rb
+++ b/db/migrate/20200706013044_add_handle_to_users.rb
@@ -1,0 +1,5 @@
+class AddHandleToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :handle, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_05_210512) do
+ActiveRecord::Schema.define(version: 2020_07_06_013044) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -76,9 +76,8 @@ ActiveRecord::Schema.define(version: 2020_07_05_210512) do
     t.integer "role", default: 0
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "handle"
-    t.string "token"
     t.string "github_token"
+    t.string "handle"
     t.index ["email"], name: "index_users_on_email"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_04_204510) do
+ActiveRecord::Schema.define(version: 2020_07_05_210512) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "friendships", force: :cascade do |t|
+    t.bigint "user_id"
+    t.bigint "friend_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["friend_id"], name: "index_friendships_on_friend_id"
+    t.index ["user_id"], name: "index_friendships_on_user_id"
+  end
 
   create_table "taggings", id: :serial, force: :cascade do |t|
     t.integer "tag_id"
@@ -67,6 +76,8 @@ ActiveRecord::Schema.define(version: 2020_07_04_204510) do
     t.integer "role", default: 0
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "handle"
+    t.string "token"
     t.string "github_token"
     t.index ["email"], name: "index_users_on_email"
   end

--- a/spec/features/user/dashboard_spec.rb
+++ b/spec/features/user/dashboard_spec.rb
@@ -71,41 +71,14 @@ describe "Registered User Profile Dashboard" do
   it "user can create friendships if user is connected through github; follower" do
 
     friend = create(:user, role: "default")
-    friend.handle = "stellakunzang"
-    # stub_omniauth_2
+    friend.update_attribute(:handle, "stellakunzang")
     visit dashboard_path
     click_on "Connect to Github"
-
-    within(".github")do
-      within(".following")do
-        click_link "Add as Friend"
-      end
-    end
-
-    expect(current_path).to eq(dashboard_path)
+    @user.update_attribute(:handle, "perryr16")
+    @user.update_attribute(:token, "placeholder")
 
     within(".github")do
       within(".followers")do
-        expect(page).to_not have_content("Add as Friend")
-        expect(page).to have_content("Already Friends")
-      end
-    end
-
-    within(".friendships")do
-      expect(page).to have_content("stellakunzang")
-    end
-  end
-
-  xit "user can create friendships if user is connected through github; following" do
-
-    friend = create(:user, role: "default")
-    friend.handle = "stellakunzang"
-    # stub_omniauth_2
-    visit dashboard_path
-    click_on "Connect to Github"
-
-    within(".github")do
-      within(".follower")do
         click_link "Add as Friend"
       end
     end
@@ -115,7 +88,6 @@ describe "Registered User Profile Dashboard" do
     within(".github")do
       within(".following")do
         expect(page).to_not have_content("Add as Friend")
-        expect(page).to have_content("Already Friends")
       end
     end
 
@@ -124,7 +96,35 @@ describe "Registered User Profile Dashboard" do
     end
   end
 
-  xit "user cannot create fiendships if user is not connected through github" do
+  it "user can create friendships if user is connected through github; following" do
+
+    friend = create(:user, role: "default")
+    friend.update_attribute(:handle, "stellakunzang")
+    visit dashboard_path
+    click_on "Connect to Github"
+    @user.update_attribute(:handle, "perryr16")
+    @user.update_attribute(:token, "placeholder")
+
+    within(".github")do
+      within(".followers")do
+        click_link "Add as Friend"
+      end
+    end
+
+    expect(current_path).to eq(dashboard_path)
+
+    within(".github")do
+      within(".following")do
+        expect(page).to_not have_content("Add as Friend")
+      end
+    end
+
+    within(".friendships")do
+      expect(page).to have_content("stellakunzang")
+    end
+  end
+
+  it "user cannot create fiendships if user is not connected through github" do
     visit dashboard_path
     click_on "Connect to Github"
 
@@ -153,11 +153,3 @@ def stub_omniauth
     credentials: {token: ENV['GITHUB_ROSS_AUTH_TOKEN']}
   })
 end
-
-# def stub_omniauth_2
-#   OmniAuth.config.test_mode = true
-#   OmniAuth.config.mock_auth[:github] = OmniAuth::AuthHash.new({
-#     provider: 'github',
-#     credentials: {token: ENV['GITHUB_STELLA_AUTH_TOKEN']}
-#   })
-# end

--- a/spec/features/user/dashboard_spec.rb
+++ b/spec/features/user/dashboard_spec.rb
@@ -8,7 +8,7 @@ describe "Registered User Profile Dashboard" do
   end
 
   it "sad: users not connected to github do not have github stats"do
-    visit dashboard_path 
+    visit dashboard_path
 
     expect(page).to have_content("Connect to Github to See Github Details")
     expect(page).to_not have_content("Repositories")
@@ -67,13 +67,97 @@ describe "Registered User Profile Dashboard" do
     end
     # expect(current_path).to eq("https://github.com/stellakunzang")
   end
-end
 
+  it "user can create friendships if user is connected through github; follower" do
+
+    friend = create(:user, role: "default")
+    friend.handle = "stellakunzang"
+    # stub_omniauth_2
+    visit dashboard_path
+    click_on "Connect to Github"
+
+    within(".github")do
+      within(".following")do
+        click_link "Add as Friend"
+      end
+    end
+
+    expect(current_path).to eq(dashboard_path)
+
+    within(".github")do
+      within(".followers")do
+        expect(page).to_not have_content("Add as Friend")
+        expect(page).to have_content("Already Friends")
+      end
+    end
+
+    within(".friendships")do
+      expect(page).to have_content("stellakunzang")
+    end
+  end
+
+  xit "user can create friendships if user is connected through github; following" do
+
+    friend = create(:user, role: "default")
+    friend.handle = "stellakunzang"
+    # stub_omniauth_2
+    visit dashboard_path
+    click_on "Connect to Github"
+
+    within(".github")do
+      within(".follower")do
+        click_link "Add as Friend"
+      end
+    end
+
+    expect(current_path).to eq(dashboard_path)
+
+    within(".github")do
+      within(".following")do
+        expect(page).to_not have_content("Add as Friend")
+        expect(page).to have_content("Already Friends")
+      end
+    end
+
+    within(".friendships")do
+      expect(page).to have_content("stellakunzang")
+    end
+  end
+
+  xit "user cannot create fiendships if user is not connected through github" do
+    visit dashboard_path
+    click_on "Connect to Github"
+
+    within(".github")do
+      within(".following")do
+        expect(page).to_not have_content("Add as Friend")
+      end
+    end
+
+    within(".github")do
+      within(".followers")do
+        expect(page).to_not have_content("Add as Friend")
+      end
+    end
+
+    within(".friendships")do
+      expect(page).to_not have_content("stellakunzang")
+    end
+  end
+end
 
 def stub_omniauth
-    OmniAuth.config.test_mode = true
-    OmniAuth.config.mock_auth[:github] = OmniAuth::AuthHash.new({
-      provider: 'github',
-      credentials: {token: ENV['GITHUB_ROSS_AUTH_TOKEN']}      
-    })
+  OmniAuth.config.test_mode = true
+  OmniAuth.config.mock_auth[:github] = OmniAuth::AuthHash.new({
+    provider: 'github',
+    credentials: {token: ENV['GITHUB_ROSS_AUTH_TOKEN']}
+  })
 end
+
+# def stub_omniauth_2
+#   OmniAuth.config.test_mode = true
+#   OmniAuth.config.mock_auth[:github] = OmniAuth::AuthHash.new({
+#     provider: 'github',
+#     credentials: {token: ENV['GITHUB_STELLA_AUTH_TOKEN']}
+#   })
+# end

--- a/spec/features/user/dashboard_spec.rb
+++ b/spec/features/user/dashboard_spec.rb
@@ -74,8 +74,6 @@ describe "Registered User Profile Dashboard" do
     friend.update_attribute(:handle, "stellakunzang")
     visit dashboard_path
     click_on "Connect to Github"
-    @user.update_attribute(:handle, "perryr16")
-    @user.update_attribute(:token, "placeholder")
 
     within(".github")do
       within(".followers")do
@@ -102,8 +100,6 @@ describe "Registered User Profile Dashboard" do
     friend.update_attribute(:handle, "stellakunzang")
     visit dashboard_path
     click_on "Connect to Github"
-    @user.update_attribute(:handle, "perryr16")
-    @user.update_attribute(:token, "placeholder")
 
     within(".github")do
       within(".followers")do


### PR DESCRIPTION
User can now add friends based on their github followers or followings, if that person has an account in our system. Once the friend is added, the "add as friend" button no longer displays and that person's name and handle and now listed under "Friends" on the dashboard. 

The current problem with the migration is that the friendship is only one way...something the user story didn't offer guidance on. We cannot call `.friends` on the friend, only on the user. 